### PR TITLE
Handle HDFS input readiness within Spark job

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,11 +227,7 @@ services:
       - ./conf/hdfs-site.xml:/opt/spark/conf/hdfs-site.xml:ro
     entrypoint: ["/bin/bash","-lc"]
     command: |
-      echo 'Waiting for input CSVs in HDFS...' ;
-      until hdfs dfs -ls /data/input/*.csv >/dev/null 2>&1; do
-        echo '  still waiting for /data/input/*.csv ...'; sleep 2;
-      done ;
-      echo 'Found input files:' ; hdfs dfs -ls /data/input/*.csv ;
+      echo 'Launching Spark batch job (input readiness handled in code)...';
       exec /opt/spark/bin/spark-submit \
         --master spark://spark-master:7077 \
         --conf spark.eventLog.enabled=true \


### PR DESCRIPTION
## Summary
- add a Spark-side wait_for_input_files helper that polls HDFS (or local) for CSVs before reading
- simplify the spark-app container command now that readiness is handled inside the job itself

## Testing
- python -m compileall apps/pipeline_batch.py

------
https://chatgpt.com/codex/tasks/task_e_68e26aae7cbc83258dd56bcdf0f240c8