### PR TITLE
Fix spark-app entrypoint to run batch job

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,14 +225,16 @@ services:
       - ./spark-events:/tmp/spark-events
       - ./conf/core-site.xml:/opt/spark/conf/core-site.xml:ro
       - ./conf/hdfs-site.xml:/opt/spark/conf/hdfs-site.xml:ro
-    entrypoint: ["/bin/bash","-lc"]
-    command: |
-      echo 'Launching Spark batch job (input readiness handled in code)...';
-      exec /opt/spark/bin/spark-submit \
-        --master spark://spark-master:7077 \
-        --conf spark.eventLog.enabled=true \
-        --conf spark.eventLog.dir=hdfs://namenode:8020/spark-events \
-        /opt/spark-apps/pipeline_batch.py
+    entrypoint:
+      - /bin/bash
+      - -lc
+      - |
+          echo 'Launching Spark batch job (input readiness handled in code)...';
+          exec /opt/spark/bin/spark-submit \
+            --master spark://spark-master:7077 \
+            --conf spark.eventLog.enabled=true \
+            --conf spark.eventLog.dir=hdfs://namenode:8020/spark-events \
+            /opt/spark-apps/pipeline_batch.py
 
   # ========================= DASHBOARD (Flask + Chart.js) =========================
   dashboard:


### PR DESCRIPTION
## Summary
- adjust the spark-app service entrypoint so the spark-submit script is passed as a single bash command
- ensure the batch job is executed instead of exiting after the echo preamble

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e286d440d083258872f69076574f2f