### PR TITLE
Improve dashboard aesthetics and layout

### DIFF
--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -4,18 +4,120 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Retail Analytics Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial; margin: 0; background: #f6f8fb; color: #111;}
-    header { background: #1f2937; color: #fff; padding: 16px 24px;}
-    h1 { margin: 0; font-size: 20px;}
-    main { padding: 16px 24px; display: grid; grid-template-columns: 1fr 1fr; grid-gap: 16px;}
-    .card { background: #fff; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,.06); padding: 16px;}
-    .full { grid-column: 1 / -1; }
-    table { width: 100%; border-collapse: collapse; }
-    th, td { padding: 8px; border-bottom: 1px solid #eee; text-align: left; font-size: 14px; }
-    th { background: #fafafa; }
-    .muted { color: #666; font-size: 12px; }
-    @media (max-width: 900px) { main { grid-template-columns: 1fr; } }
+    :root {
+      color-scheme: light;
+      font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial;
+      --bg: #f3f5f9;
+      --card: #ffffff;
+      --primary: #1f2937;
+      --muted: #6b7280;
+      --border: #e5e7eb;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: radial-gradient(circle at top, rgba(59,130,246,0.12), transparent 55%), var(--bg);
+      color: var(--primary);
+      display: flex;
+      flex-direction: column;
+    }
+    header {
+      background: rgba(17,24,39,0.92);
+      color: #fff;
+      padding: 20px 32px;
+      box-shadow: 0 8px 20px rgba(15,23,42,0.2);
+      position: sticky;
+      top: 0;
+      z-index: 2;
+    }
+    h1 {
+      margin: 0;
+      font-size: 24px;
+      letter-spacing: -0.01em;
+      display: flex;
+      gap: 12px;
+      align-items: baseline;
+    }
+    main {
+      flex: 1;
+      padding: 24px clamp(16px, 4vw, 48px) 48px;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 24px;
+      max-width: 1200px;
+      width: 100%;
+      margin: 0 auto;
+    }
+    .card {
+      background: var(--card);
+      border-radius: 20px;
+      box-shadow: 0 10px 30px rgba(15,23,42,0.08);
+      padding: 20px 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      overflow: hidden;
+    }
+    .card h3 {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+    .full {
+      grid-column: 1 / -1;
+    }
+    .chart-container {
+      position: relative;
+      height: 280px;
+      width: 100%;
+    }
+    .table-wrapper {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      overflow: auto;
+      max-height: 320px;
+      background: #fff;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+    thead th {
+      position: sticky;
+      top: 0;
+      background: #f9fafb;
+      z-index: 1;
+    }
+    th, td {
+      padding: 10px 16px;
+      border-bottom: 1px solid var(--border);
+      text-align: left;
+      white-space: nowrap;
+    }
+    tbody tr:nth-child(odd) {
+      background: #f9fafb;
+    }
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+    .muted {
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 500;
+    }
+    @media (max-width: 720px) {
+      h1 { font-size: 20px; flex-direction: column; gap: 4px; }
+      main { padding-bottom: 32px; }
+      .chart-container { height: 220px; }
+      .table-wrapper { max-height: 260px; }
+    }
   </style>
 </head>
 <body>
@@ -24,16 +126,29 @@
   </header>
   <main>
     <section class="card">
-      <h3>Revenue by Day</h3>
-      <canvas id="chartDaily"></canvas>
+      <div>
+        <h3>Revenue by Day</h3>
+        <p class="muted">Overall daily revenue trend</p>
+      </div>
+      <div class="chart-container">
+        <canvas id="chartDaily"></canvas>
+      </div>
     </section>
     <section class="card">
-      <h3>Top 10 Products</h3>
-      <canvas id="chartProducts"></canvas>
+      <div>
+        <h3>Top 10 Products</h3>
+        <p class="muted">Highest grossing products</p>
+      </div>
+      <div class="chart-container">
+        <canvas id="chartProducts"></canvas>
+      </div>
     </section>
     <section class="card full">
-      <h3>Sample Output Rows</h3>
-      <div id="table"></div>
+      <div>
+        <h3>Sample Output Rows</h3>
+        <p class="muted">Latest processed orders</p>
+      </div>
+      <div id="table" class="table-wrapper"></div>
     </section>
   </main>
 

--- a/dashboard/static/script.js
+++ b/dashboard/static/script.js
@@ -1,10 +1,41 @@
+const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+
+Chart.defaults.font.family = "Inter, system-ui, -apple-system, Segoe UI, Roboto";
+Chart.defaults.color = '#1f2937';
+Chart.defaults.plugins.tooltip.backgroundColor = 'rgba(17,24,39,0.92)';
+Chart.defaults.plugins.tooltip.titleColor = '#fff';
+Chart.defaults.plugins.tooltip.bodyColor = '#e5e7eb';
+
+function buildTable(rows){
+  if(!rows?.length){
+    return '<div style="padding:24px;text-align:center" class="muted">No rows to display.</div>';
+  }
+  const cells = rows.map(r => `
+    <tr>
+      <td>${r.order_date}</td>
+      <td>${r.product}</td>
+      <td>${currencyFormatter.format(r.total_amount)}</td>
+    </tr>
+  `);
+  return `
+    <table>
+      <thead>
+        <tr><th>order_date</th><th>product</th><th>total_amount</th></tr>
+      </thead>
+      <tbody>${cells.join('')}</tbody>
+    </table>
+  `;
+}
+
 async function loadData(){
   const res = await fetch('/api/daily');
   const data = await res.json();
+
   if(data.status !== 'ok'){
-    document.getElementById('table').innerHTML = '<p class="muted">No data yet. Run the Spark job.</p>';
+    document.getElementById('table').innerHTML = '<div style="padding:24px;text-align:center" class="muted">No data yet. Run the Spark job.</div>';
     return;
   }
+
   const days = data.daily.map(d => d.order_date);
   const totals = data.daily.map(d => d.total_amount);
 
@@ -13,9 +44,42 @@ async function loadData(){
     type: 'line',
     data: {
       labels: days,
-      datasets: [{ label: 'Total Revenue', data: totals }]
+      datasets: [{
+        label: 'Total Revenue',
+        data: totals,
+        tension: 0.35,
+        borderWidth: 3,
+        borderColor: 'rgba(59,130,246,0.9)',
+        backgroundColor: 'rgba(59,130,246,0.15)',
+        fill: true,
+        pointRadius: 4,
+        pointHoverRadius: 6,
+        pointBackgroundColor: '#1d4ed8'
+      }]
     },
-    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: true } } }
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label: ctx => `${ctx.dataset.label}: ${currencyFormatter.format(ctx.parsed.y)}`
+          }
+        }
+      },
+      scales: {
+        y: {
+          ticks: {
+            callback: value => currencyFormatter.format(value)
+          },
+          grid: { color: 'rgba(148,163,184,0.2)' }
+        },
+        x: {
+          grid: { display: false }
+        }
+      }
+    }
   });
 
   const products = data.top_products.map(d => d.product);
@@ -23,20 +87,43 @@ async function loadData(){
   const ctxProducts = document.getElementById('chartProducts').getContext('2d');
   new Chart(ctxProducts, {
     type: 'bar',
-    data: { labels: products, datasets: [{ label: 'Total Revenue', data: pTotals }]},
-    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } } }
+    data: {
+      labels: products,
+      datasets: [{
+        label: 'Total Revenue',
+        data: pTotals,
+        backgroundColor: products.map((_, idx) => `rgba(14,165,233,${0.4 + (idx/products.length)*0.5})`),
+        borderRadius: 10,
+        borderSkipped: false
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label: ctx => `${ctx.label}: ${currencyFormatter.format(ctx.parsed.y)}`
+          }
+        }
+      },
+      scales: {
+        y: {
+          ticks: {
+            callback: value => currencyFormatter.format(value)
+          },
+          grid: { color: 'rgba(148,163,184,0.2)' }
+        },
+        x: {
+          ticks: { maxRotation: 0, minRotation: 0, autoSkip: true, maxTicksLimit: 5 },
+          grid: { display: false }
+        }
+      }
+    }
   });
 
-  // Table
-  const rows = data.sample;
-  const table = [
-    '<table>',
-    '<thead><tr><th>order_date</th><th>product</th><th>total_amount</th></tr></thead>',
-    '<tbody>',
-    ...rows.map(r => `<tr><td>${r.order_date}</td><td>${r.product}</td><td>${r.total_amount}</td></tr>`),
-    '</tbody>',
-    '</table>'
-  ].join('');
-  document.getElementById('table').innerHTML = table;
+  document.getElementById('table').innerHTML = buildTable(data.sample);
 }
+
 loadData();


### PR DESCRIPTION
## Summary
- refresh the dashboard styling with modern typography, gradients, and responsive card layout that fits within a single viewport
- enhance revenue and product charts with custom colors, smoothing, and currency-aware tooltips
- polish the sample data table with sticky headers, scrolling, and empty-state messaging

## Testing
- python dashboard/app.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a0338d5c832596f2f068c8ea5b8d