### PR TITLE
Add Kafka streaming producer and Spark Structured Streaming job

### DIFF
--- a/apps/kafka_event_producer.py
+++ b/apps/kafka_event_producer.py
@@ -1,0 +1,189 @@
+"""Kafka event generator for retail sales demo.
+
+This script replays CSV input files as JSON order events to a Kafka topic.
+It is intentionally lightweight so it can run either directly on the host
+or inside the `event-generator` service defined in ``docker-compose.yml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import os
+import random
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List
+
+from kafka import KafkaProducer
+
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(line_buffering=True)
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(line_buffering=True)
+
+logger = logging.getLogger("retail.kafka.producer")
+
+
+@dataclass
+class ProducerConfig:
+    """Runtime configuration derived from CLI arguments."""
+
+    bootstrap_servers: str
+    topic: str
+    input_dir: Path
+    rate_per_second: float
+    shuffle: bool
+    loop: bool
+
+
+class EventProducer:
+    """Replay CSV sales rows to Kafka as JSON order events."""
+
+    def __init__(self, config: ProducerConfig) -> None:
+        self._config = config
+        self._producer = KafkaProducer(
+            bootstrap_servers=config.bootstrap_servers,
+            value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+            linger_ms=100,
+        )
+
+    def _discover_csv_files(self) -> List[Path]:
+        files = sorted(self._config.input_dir.glob("*.csv"))
+        if not files:
+            raise FileNotFoundError(
+                f"No CSV files found under {self._config.input_dir}"
+            )
+        return files
+
+    def _iter_rows(self, files: Iterable[Path]) -> Iterator[Dict[str, str]]:
+        for path in files:
+            logger.info("Loading %s", path)
+            with path.open("r", newline="") as fh:
+                reader = csv.DictReader(fh)
+                for row in reader:
+                    if not any(row.values()):
+                        continue
+                    clean = {k.strip(): (v.strip() if isinstance(v, str) else v)
+                             for k, v in row.items()}
+                    yield clean
+
+    def _normalise_row(self, row: Dict[str, str]) -> Dict[str, str]:
+        payload = dict(row)
+        # Provide a consistent timestamp field for the stream job.
+        for candidate in ("order_ts", "order_time", "order_date", "timestamp"):
+            if candidate in payload and payload[candidate]:
+                payload["event_time"] = payload[candidate]
+                break
+        if "event_time" not in payload:
+            payload["event_time"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+        return payload
+
+    def run(self) -> None:
+        files = self._discover_csv_files()
+        logger.info(
+            "Starting producer with rate %.2f msg/s (shuffle=%s, loop=%s)",
+            self._config.rate_per_second,
+            self._config.shuffle,
+            self._config.loop,
+        )
+
+        rows = list(self._iter_rows(files))
+        if self._config.shuffle:
+            random.shuffle(rows)
+
+        delay = 1.0 / self._config.rate_per_second if self._config.rate_per_second > 0 else 0
+
+        sent = 0
+        try:
+            while True:
+                for row in rows:
+                    payload = self._normalise_row(row)
+                    self._producer.send(self._config.topic, payload)
+                    sent += 1
+                    if sent % 100 == 0:
+                        logger.info("Published %d events", sent)
+                    if delay > 0:
+                        time.sleep(delay)
+                if not self._config.loop:
+                    break
+                if self._config.shuffle:
+                    random.shuffle(rows)
+        finally:
+            logger.info("Flushing producer (sent %d events)", sent)
+            self._producer.flush()
+            self._producer.close()
+
+
+def parse_args(argv: List[str]) -> ProducerConfig:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--bootstrap-servers",
+        default=os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092"),
+        help="Kafka bootstrap server string",
+    )
+    parser.add_argument(
+        "--topic",
+        default=os.environ.get("KAFKA_TOPIC", "sales"),
+        help="Kafka topic to publish to",
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=Path(os.environ.get("EVENT_INPUT_DIR", "/opt/spark-data/input")),
+        help="Directory containing CSV files to replay",
+    )
+    parser.add_argument(
+        "--rate",
+        type=float,
+        default=float(os.environ.get("EVENTS_PER_SECOND", "5")),
+        help="Target events per second (<=0 for as fast as possible)",
+    )
+    parser.add_argument(
+        "--shuffle",
+        action="store_true",
+        help="Randomise the order of events within the loaded dataset",
+    )
+    parser.add_argument(
+        "--loop",
+        action="store_true",
+        help="Continuously loop over the dataset instead of stopping after one pass",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=os.environ.get("LOG_LEVEL", "INFO"),
+        help="Logging level",
+    )
+
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="[%(asctime)s] [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    config = ProducerConfig(
+        bootstrap_servers=args.bootstrap_servers,
+        topic=args.topic,
+        input_dir=args.input_dir,
+        rate_per_second=max(args.rate, 0.0),
+        shuffle=args.shuffle,
+        loop=args.loop,
+    )
+    return config
+
+
+def main(argv: List[str] | None = None) -> None:
+    config = parse_args(argv or sys.argv[1:])
+    producer = EventProducer(config)
+    producer.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/streaming_sales_aggregator.py
+++ b/apps/streaming_sales_aggregator.py
@@ -1,0 +1,197 @@
+"""Structured Streaming job for real-time retail analytics.
+
+The job consumes JSON order events from Kafka, applies the same cleansing
+rules as the batch pipeline and maintains rolling revenue metrics per
+product. Results are persisted to HDFS in parquet format so that the
+existing dashboard (or other tools) can use the aggregated outputs.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Optional
+
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.column import Column
+from pyspark.sql.functions import (
+    col,
+    from_json,
+    lit,
+    round as round_,
+    sum as sum_,
+    to_date,
+    to_timestamp,
+    trim,
+    when,
+    window,
+)
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
+
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(line_buffering=True)
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(line_buffering=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger("retail.stream")
+
+
+APP_NAME = "stream.retail_sales_aggregator"
+KAFKA_BOOTSTRAP = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+KAFKA_TOPIC = os.environ.get("KAFKA_TOPIC", "sales")
+CHECKPOINT_DIR = os.environ.get("STREAM_CHECKPOINT_DIR", "/opt/spark-checkpoints/streaming_sales")
+OUTPUT_PATH = os.environ.get("STREAM_OUTPUT_PATH", "hdfs://namenode:8020/data/output/streaming_product_revenue")
+
+
+def build_spark_session() -> SparkSession:
+    logger.info("Creating Spark session '%s'", APP_NAME)
+    spark = (
+        SparkSession.builder
+        .appName(APP_NAME)
+        .config("spark.sql.session.timeZone", "UTC")
+        .config("spark.sql.shuffle.partitions", os.environ.get("SPARK_SHUFFLE_PARTITIONS", "4"))
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("WARN")
+    return spark
+
+
+EVENT_SCHEMA = StructType([
+    StructField("order_id", StringType(), True),
+    StructField("order_date", StringType(), True),
+    StructField("order_time", StringType(), True),
+    StructField("event_time", StringType(), True),
+    StructField("timestamp", StringType(), True),
+    StructField("product", StringType(), True),
+    StructField("item", StringType(), True),
+    StructField("quantity", StringType(), True),
+    StructField("unit_price", StringType(), True),
+    StructField("total_price", StringType(), True),
+    StructField("customer_id", StringType(), True),
+    StructField("store", StringType(), True),
+])
+
+
+def transform_orders(df: DataFrame) -> DataFrame:
+    logger.info("Applying cleansing and derived columns to event stream")
+
+    cols = df.columns
+
+    product_col = "product" if "product" in cols else ("item" if "item" in cols else None)
+    if product_col:
+        df = df.withColumn("product", trim(col(product_col)))
+    else:
+        df = df.withColumn("product", lit("UNKNOWN"))
+
+    # Build an event timestamp from available fields
+    def choose_timestamp(*candidates: str) -> Optional[Column]:
+        for cand in candidates:
+            if cand and cand in cols:
+                return col(cand)
+        return None
+
+    ts_expr = choose_timestamp("event_time", "order_time", "order_date", "timestamp")
+    if ts_expr is None:
+        df = df.withColumn("order_ts", to_timestamp(lit("1970-01-01 00:00:00")))
+    else:
+        df = df.withColumn("order_ts", to_timestamp(ts_expr))
+
+    df = df.withColumn("order_date", to_date(col("order_ts")))
+
+    df = (
+        df
+        .withColumn("quantity", col("quantity").cast(DoubleType()))
+        .withColumn("unit_price", col("unit_price").cast(DoubleType()))
+        .withColumn("total_price", col("total_price").cast(DoubleType()))
+    )
+
+    df = df.withColumn(
+        "line_amount",
+        when(col("total_price").isNotNull(), col("total_price").cast(DoubleType()))
+        .otherwise(col("quantity") * col("unit_price")),
+    )
+
+    df = df.withColumn(
+        "line_amount",
+        round_(
+            when(col("line_amount").isNull(), lit(0.0)).otherwise(col("line_amount")),
+            2,
+        ),
+    )
+
+    return df.filter(col("order_ts").isNotNull())
+
+
+def build_aggregations(df: DataFrame) -> DataFrame:
+    logger.info("Creating revenue aggregates per product and hour window")
+    return (
+        df
+        .withWatermark("order_ts", "15 minutes")
+        .groupBy(
+            window(col("order_ts"), "1 hour", "15 minutes").alias("time_window"),
+            col("product"),
+        )
+        .agg(
+            sum_(col("line_amount")).alias("revenue"),
+        )
+        .select(
+            col("product"),
+            round_(col("revenue"), 2).alias("revenue"),
+            col("time_window.start").alias("window_start"),
+            col("time_window.end").alias("window_end"),
+        )
+    )
+
+
+def main() -> None:
+    spark = build_spark_session()
+
+    logger.info(
+        "Subscribing to Kafka topic '%s' at %s", KAFKA_TOPIC, KAFKA_BOOTSTRAP
+    )
+
+    raw_stream = (
+        spark.readStream
+        .format("kafka")
+        .option("kafka.bootstrap.servers", KAFKA_BOOTSTRAP)
+        .option("subscribe", KAFKA_TOPIC)
+        .option("startingOffsets", os.environ.get("KAFKA_STARTING_OFFSETS", "latest"))
+        .load()
+    )
+
+    parsed_stream = (
+        raw_stream
+        .select(from_json(col("value").cast("string"), EVENT_SCHEMA).alias("event"))
+        .select("event.*")
+    )
+
+    cleaned = transform_orders(parsed_stream)
+    aggregates = build_aggregations(cleaned)
+
+    query = (
+        aggregates.writeStream
+        .outputMode("update")
+        .format("parquet")
+        .option("path", OUTPUT_PATH)
+        .option("checkpointLocation", CHECKPOINT_DIR)
+        .trigger(processingTime=os.environ.get("STREAM_TRIGGER_INTERVAL", "30 seconds"))
+    )
+
+    logger.info(
+        "Starting streaming query with checkpoint %s and output %s",
+        CHECKPOINT_DIR,
+        OUTPUT_PATH,
+    )
+
+    query.start().awaitTermination()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,7 @@ services:
       - spark-worker-1
       - spark-worker-2
       - hdfs-init
+      - kafka
     environment:
       - PYSPARK_PYTHON=python3
       - PYSPARK_DRIVER_PYTHON=python3
@@ -235,6 +236,57 @@ services:
             --conf spark.eventLog.enabled=true \
             --conf spark.eventLog.dir=hdfs://namenode:8020/spark-events \
             /opt/spark-apps/pipeline_batch.py
+
+  # --- Continuous Structured Streaming job reading Kafka 'sales' topic ---
+  spark-stream:
+    image: apache/spark:latest
+    container_name: spark-stream
+    depends_on:
+      - kafka
+      - spark-master
+      - spark-worker-1
+      - spark-worker-2
+      - hdfs-init
+    environment:
+      - PYSPARK_PYTHON=python3
+      - PYSPARK_DRIVER_PYTHON=python3
+    volumes:
+      - ./apps:/opt/spark-apps
+      - ./data:/opt/spark-data
+      - ./checkpoints:/opt/spark-checkpoints
+      - ./spark-events:/tmp/spark-events
+      - ./conf/core-site.xml:/opt/spark/conf/core-site.xml:ro
+      - ./conf/hdfs-site.xml:/opt/spark/conf/hdfs-site.xml:ro
+    entrypoint:
+      - /bin/bash
+      - -lc
+      - |
+          echo 'Launching Spark streaming job (Kafka -> HDFS aggregates)...';
+          exec /opt/spark/bin/spark-submit \
+            --master spark://spark-master:7077 \
+            --conf spark.eventLog.enabled=true \
+            --conf spark.eventLog.dir=hdfs://namenode:8020/spark-events \
+            /opt/spark-apps/streaming_sales_aggregator.py
+
+  # --- Kafka event generator that replays CSV orders into the stream ---
+  event-generator:
+    build:
+      context: .
+      dockerfile: producers/Dockerfile
+    container_name: event-generator
+    depends_on:
+      - kafka
+      - hdfs-init
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - KAFKA_TOPIC=sales
+      - EVENTS_PER_SECOND=5
+      - EVENT_INPUT_DIR=/opt/spark-data/input
+    volumes:
+      - ./data:/opt/spark-data
+    command:
+      - --loop
+      - --shuffle
 
   # ========================= DASHBOARD (Flask + Chart.js) =========================
   dashboard:

--- a/producers/Dockerfile
+++ b/producers/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir kafka-python
+
+WORKDIR /app
+COPY apps/kafka_event_producer.py /app/producer.py
+
+ENTRYPOINT ["python", "producer.py"]


### PR DESCRIPTION
## Summary
- add a Python Kafka producer that replays the demo CSV sales data as JSON events
- add a Spark Structured Streaming job that aggregates Kafka sales events into hourly product revenue parquet outputs
- wire the new services into docker-compose and document how to run the streaming pipeline

## Testing
- python -m py_compile apps/kafka_event_producer.py apps/streaming_sales_aggregator.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a24b57088325a8d91f6f5f483fde