### PR TITLE
Fix streaming dashboard build context for Docker Compose

### DIFF
--- a/docker-compose.streaming.yml
+++ b/docker-compose.streaming.yml
@@ -252,8 +252,8 @@ services:
 
   streaming-dashboard:
     build:
-      context: .
-      dockerfile: streaming_dashboard/Dockerfile
+      context: ./streaming_dashboard
+      dockerfile: Dockerfile
     container_name: streaming-dashboard
     depends_on:
       - spark-stream


### PR DESCRIPTION
## Summary
- point the streaming dashboard service build context to the local streaming_dashboard directory so Docker can find its resources

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e329c194ec8325b53610293ba2b8df