### PR TITLE
Fix streaming parquet sink mode

### DIFF
--- a/services/streaming/streaming_sales_aggregator.py
+++ b/services/streaming/streaming_sales_aggregator.py
@@ -196,7 +196,7 @@ def main() -> None:
 
     query = (
         aggregates.writeStream
-        .outputMode("update")
+        .outputMode("append")
         .format("parquet")
         .option("path", OUTPUT_PATH)
         .option("checkpointLocation", CHECKPOINT_DIR)


### PR DESCRIPTION
## Summary
- use append output mode for the streaming parquet sink so the query can run

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e38ae953d08325ad80c1ac70bfe6aa