### PR TITLE
Ensure Spark streaming service loads Kafka connector

### DIFF
--- a/docker-compose.streaming.yml
+++ b/docker-compose.streaming.yml
@@ -229,6 +229,7 @@ services:
             --master spark://spark-master:7077 \
             --conf spark.eventLog.enabled=true \
             --conf spark.eventLog.dir=hdfs://namenode:8020/spark-events \
+            --packages ${SPARK_KAFKA_PACKAGE:-org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1} \
             /opt/services/streaming/streaming_sales_aggregator.py
 
   event-generator:


### PR DESCRIPTION
## Summary
- add the Spark Kafka connector package to the spark-stream submission command so the Kafka source is available at runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e39f38f0f08325b4616bb617ea2f21