### PR TITLE
Configure Ivy cache directory for streaming job

### DIFF
--- a/docker-compose.streaming.yml
+++ b/docker-compose.streaming.yml
@@ -225,10 +225,14 @@ services:
       - -lc
       - |
           echo 'Launching Spark streaming job (Kafka -> HDFS aggregates)...';
+          IVY_DIR="${SPARK_IVY_DIR:-/tmp/.ivy2}"
+          mkdir -p "${IVY_DIR}/cache" "${IVY_DIR}/jars"
+          echo "Using Ivy cache directory ${IVY_DIR}"
           exec /opt/spark/bin/spark-submit \
             --master spark://spark-master:7077 \
             --conf spark.eventLog.enabled=true \
             --conf spark.eventLog.dir=hdfs://namenode:8020/spark-events \
+            --conf spark.jars.ivy=${IVY_DIR} \
             --packages ${SPARK_KAFKA_PACKAGE:-org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1} \
             /opt/services/streaming/streaming_sales_aggregator.py
 


### PR DESCRIPTION
## Summary
- ensure the streaming spark container provisions a writable Ivy cache directory before launching the job
- configure spark-submit to use the explicit cache path so dependency resolution no longer fails

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e3a293e4f4832587258c0946407f51