### PR TITLE
Add fallback for Spark Ivy cache directory

### DIFF
--- a/docker-compose.streaming.yml
+++ b/docker-compose.streaming.yml
@@ -232,7 +232,12 @@ services:
           fi
           if ! mkdir -p "${IVY_DIR}/cache" "${IVY_DIR}/jars"; then
             echo "Failed to create Ivy cache directories under ${IVY_DIR}" >&2
-            exit 1
+            IVY_DIR="/tmp/.ivy2"
+            echo "Falling back to default Ivy cache directory ${IVY_DIR}" >&2
+            if ! mkdir -p "${IVY_DIR}/cache" "${IVY_DIR}/jars"; then
+              echo "Unable to create fallback Ivy cache directories under ${IVY_DIR}" >&2
+              exit 1
+            fi
           fi
           echo "Using Ivy cache directory ${IVY_DIR}"
           exec /opt/spark/bin/spark-submit \


### PR DESCRIPTION
## Summary
- add a fallback Ivy cache directory for the spark-stream container entrypoint
- ensure the script uses /tmp/.ivy2 if the configured directory cannot be created

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e0346d7883259b575012ef00093d