### PR TITLE
Fix Ivy env var warning in streaming compose

### DIFF
--- a/docker-compose.streaming.yml
+++ b/docker-compose.streaming.yml
@@ -226,26 +226,26 @@ services:
       - -lc
       - |
           echo 'Launching Spark streaming job (Kafka -> HDFS aggregates)...';
-          IVY_DIR="${SPARK_IVY_DIR:-/tmp/.ivy2}"
-          if [ -z "${IVY_DIR}" ]; then
+          IVY_DIR="$${SPARK_IVY_DIR:-/tmp/.ivy2}"
+          if [ -z "$${IVY_DIR}" ]; then
             IVY_DIR="/tmp/.ivy2"
           fi
-          if ! mkdir -p "${IVY_DIR}/cache" "${IVY_DIR}/jars"; then
-            echo "Failed to create Ivy cache directories under ${IVY_DIR}" >&2
+          if ! mkdir -p "$${IVY_DIR}/cache" "$${IVY_DIR}/jars"; then
+            echo "Failed to create Ivy cache directories under $${IVY_DIR}" >&2
             IVY_DIR="/tmp/.ivy2"
-            echo "Falling back to default Ivy cache directory ${IVY_DIR}" >&2
-            if ! mkdir -p "${IVY_DIR}/cache" "${IVY_DIR}/jars"; then
-              echo "Unable to create fallback Ivy cache directories under ${IVY_DIR}" >&2
+            echo "Falling back to default Ivy cache directory $${IVY_DIR}" >&2
+            if ! mkdir -p "$${IVY_DIR}/cache" "$${IVY_DIR}/jars"; then
+              echo "Unable to create fallback Ivy cache directories under $${IVY_DIR}" >&2
               exit 1
             fi
           fi
-          echo "Using Ivy cache directory ${IVY_DIR}"
+          echo "Using Ivy cache directory $${IVY_DIR}"
           exec /opt/spark/bin/spark-submit \
             --master spark://spark-master:7077 \
             --conf spark.eventLog.enabled=true \
             --conf spark.eventLog.dir=hdfs://namenode:8020/spark-events \
-            --conf spark.jars.ivy=${IVY_DIR} \
-            --packages ${SPARK_KAFKA_PACKAGE:-org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1} \
+            --conf spark.jars.ivy=$${IVY_DIR} \
+            --packages $${SPARK_KAFKA_PACKAGE:-org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1} \
             /opt/services/streaming/streaming_sales_aggregator.py
 
   event-generator:


### PR DESCRIPTION
## Summary
- escape Ivy-related environment variable references in the spark-stream entrypoint script
- ensure docker compose no longer emits IVY_DIR warnings while keeping runtime behavior the same

## Testing
- not run (infrastructure change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3e69afd7c83258ce71603894000c8