### PR TITLE
Handle Kafka data loss gracefully

### DIFF
--- a/services/streaming/streaming_sales_aggregator.py
+++ b/services/streaming/streaming_sales_aggregator.py
@@ -310,6 +310,10 @@ def main() -> None:
         .option("kafka.bootstrap.servers", KAFKA_BOOTSTRAP)
         .option("subscribe", KAFKA_TOPIC)
         .option("startingOffsets", os.environ.get("KAFKA_STARTING_OFFSETS", "latest"))
+        # Avoid failing the query if Kafka has already aged out old offsets. In production
+        # this should be paired with robust checkpointing/monitoring, but for local demos
+        # we prefer continuity over strict failure semantics.
+        .option("failOnDataLoss", "false")
         .load()
     )
 


### PR DESCRIPTION
## Summary
- prevent streaming job failures when Kafka offsets are aged out by disabling failOnDataLoss
- document why the relaxed behaviour is acceptable for local/demo usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e520d4af88832585c0481c975dd93f