### PR TITLE
Update batch dashboard currency and sample ordering

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -39,8 +39,8 @@ def api_daily():
         df.groupby("product")["total_amount"]
           .sum().reset_index().sort_values("total_amount", ascending=False).head(10)
     )
-    # sample table
-    sample_rows = df.sort_values(["order_date","product"]).head(50)
+    # sample table - show most recent orders first
+    sample_rows = df.sort_values(["order_date", "product"], ascending=[False, True]).head(50)
 
     return jsonify({
         "status": "ok",

--- a/dashboard/static/script.js
+++ b/dashboard/static/script.js
@@ -1,4 +1,8 @@
-const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+const currencyFormatter = new Intl.NumberFormat('en-IN', {
+  style: 'currency',
+  currency: 'INR',
+  maximumFractionDigits: 0,
+});
 
 Chart.defaults.font.family = "Inter, system-ui, -apple-system, Segoe UI, Roboto";
 Chart.defaults.color = '#1f2937';


### PR DESCRIPTION
## Summary
- switch the dashboard charts and sample table to display Indian Rupees instead of US Dollars
- surface the most recent processed rows first in the sample output table returned by the API

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e52dc50c2c83259d46966d328b2078